### PR TITLE
Use strict_encode64

### DIFF
--- a/services/sonos_service.rb
+++ b/services/sonos_service.rb
@@ -76,7 +76,7 @@ module JukeBotService
     end
 
     def auth_token
-      Base64.encode64("#{ENV['USERNAME']}:#{ENV['PASSWORD']}")
+      Base64.strict_encode64("#{ENV['USERNAME']}:#{ENV['PASSWORD']}")
     end
   end
 end


### PR DESCRIPTION
I hit this when using a long password.  The docs for `Base64.encode64` state "Line feeds are added to every 60 encoded characters.".  `strict64` doesn't do this.