### PR TITLE
Move to async-websocket

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,11 +1,9 @@
 source 'https://rubygems.org'
-ruby '2.3.1'
 
 gem 'slack-ruby-bot'
+gem 'async-websocket', '~> 0.8.0'
 
 gem 'blanket_wrapper'
-gem 'celluloid-io'
 gem 'dotenv'
 gem 'nokogiri'
-gem 'pry'
 gem 'rspotify'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,130 +1,110 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (5.1.4)
+    activesupport (5.2.3)
       concurrent-ruby (~> 1.0, >= 1.0.2)
-      i18n (~> 0.7)
+      i18n (>= 0.7, < 2)
       minitest (~> 5.1)
       tzinfo (~> 1.1)
+    addressable (2.5.2)
+      public_suffix (>= 2.0.2, < 4.0)
+    async (1.17.1)
+      console (~> 1.0)
+      nio4r (~> 2.3)
+      timers (~> 4.1)
+    async-io (1.23.1)
+      async (~> 1.14)
+    async-websocket (0.8.0)
+      async-io
+      websocket-driver (~> 0.7.0)
     blanket_wrapper (3.0.2)
       httparty
       recursive-open-struct
-    celluloid (0.17.3)
-      celluloid-essentials
-      celluloid-extras
-      celluloid-fsm
-      celluloid-pool
-      celluloid-supervision
-      timers (>= 4.1.1)
-    celluloid-essentials (0.20.5)
-      timers (>= 4.1.1)
-    celluloid-extras (0.20.5)
-      timers (>= 4.1.1)
-    celluloid-fsm (0.20.5)
-      timers (>= 4.1.1)
-    celluloid-io (0.17.3)
-      celluloid (>= 0.17.2)
-      nio4r (>= 1.1)
-      timers (>= 4.1.1)
-    celluloid-pool (0.20.5)
-      timers (>= 4.1.1)
-    celluloid-supervision (0.20.6)
-      timers (>= 4.1.1)
-    coderay (1.1.1)
-    concurrent-ruby (1.0.5)
-    domain_name (0.5.20170404)
+    concurrent-ruby (1.1.5)
+    console (1.2.4)
+    domain_name (0.5.20180417)
       unf (>= 0.0.5, < 1.0.0)
-    dotenv (2.2.1)
-    faraday (0.13.1)
+    dotenv (2.7.2)
+    faraday (0.15.4)
       multipart-post (>= 1.2, < 3)
-    faraday_middleware (0.12.2)
+    faraday_middleware (0.13.1)
       faraday (>= 0.7.4, < 1.0)
-    gli (2.16.1)
-    hashie (3.5.6)
-    hitimes (1.2.6)
+    gli (2.18.0)
+    hashie (3.6.0)
     http-cookie (1.0.3)
       domain_name (~> 0.5)
-    httparty (0.15.6)
+    httparty (0.17.0)
+      mime-types (~> 3.0)
       multi_xml (>= 0.5.2)
-    httpauth (0.2.1)
-    i18n (0.8.6)
-    json (2.1.0)
-    jwt (0.1.13)
-      multi_json (>= 1.5)
-    method_source (0.8.2)
-    mime-types (2.99.3)
-    mini_portile2 (2.3.0)
-    minitest (5.10.3)
-    multi_json (1.12.2)
+    i18n (1.6.0)
+      concurrent-ruby (~> 1.0)
+    jwt (2.1.0)
+    mime-types (3.2.2)
+      mime-types-data (~> 3.2015)
+    mime-types-data (3.2019.0331)
+    mini_portile2 (2.4.0)
+    minitest (5.11.3)
+    multi_json (1.13.1)
     multi_xml (0.6.0)
-    multipart-post (2.0.0)
+    multipart-post (2.1.1)
     netrc (0.11.0)
-    nio4r (2.1.0)
-    nokogiri (1.8.1)
-      mini_portile2 (~> 2.3.0)
-    oauth2 (0.8.1)
-      faraday (~> 0.8)
-      httpauth (~> 0.1)
-      jwt (~> 0.1.4)
-      multi_json (~> 1.0)
-      rack (~> 1.2)
-    omniauth (1.7.1)
-      hashie (>= 3.4.6, < 3.6.0)
+    nio4r (2.3.1)
+    nokogiri (1.10.3)
+      mini_portile2 (~> 2.4.0)
+    oauth2 (1.4.1)
+      faraday (>= 0.8, < 0.16.0)
+      jwt (>= 1.0, < 3.0)
+      multi_json (~> 1.3)
+      multi_xml (~> 0.5)
+      rack (>= 1.2, < 3)
+    omniauth (1.9.0)
+      hashie (>= 3.4.6, < 3.7.0)
       rack (>= 1.6.2, < 3)
-    omniauth-oauth2 (1.1.1)
-      oauth2 (~> 0.8.0)
-      omniauth (~> 1.0)
-    pry (0.10.4)
-      coderay (~> 1.1.0)
-      method_source (~> 0.8.1)
-      slop (~> 3.4)
-    rack (1.6.8)
-    recursive-open-struct (1.0.5)
-    rest-client (1.8.0)
+    omniauth-oauth2 (1.5.0)
+      oauth2 (~> 1.1)
+      omniauth (~> 1.2)
+    public_suffix (3.0.3)
+    rack (2.0.7)
+    recursive-open-struct (1.1.0)
+    rest-client (2.0.2)
       http-cookie (>= 1.0.2, < 2.0)
-      mime-types (>= 1.16, < 3.0)
-      netrc (~> 0.7)
-    rspotify (1.15.4)
-      omniauth-oauth2 (~> 1.1)
-      rest-client (~> 1.7)
-    slack-ruby-bot (0.10.4)
+      mime-types (>= 1.16, < 4.0)
+      netrc (~> 0.8)
+    rspotify (2.6.0)
+      addressable (~> 2.5.2)
+      omniauth-oauth2 (~> 1.5.0)
+      rest-client (~> 2.0.2)
+    slack-ruby-bot (0.12.0)
       hashie
-      slack-ruby-client (>= 0.6.0)
-    slack-ruby-client (0.10.0)
+      slack-ruby-client (>= 0.14.0)
+    slack-ruby-client (0.14.2)
       activesupport
       faraday (>= 0.9)
       faraday_middleware
       gli
       hashie
-      json
       websocket-driver
-    slop (3.6.0)
     thread_safe (0.3.6)
-    timers (4.1.2)
-      hitimes
-    tzinfo (1.2.3)
+    timers (4.3.0)
+    tzinfo (1.2.5)
       thread_safe (~> 0.1)
     unf (0.1.4)
       unf_ext
-    unf_ext (0.0.7.4)
+    unf_ext (0.0.7.6)
     websocket-driver (0.7.0)
       websocket-extensions (>= 0.1.0)
-    websocket-extensions (0.1.2)
+    websocket-extensions (0.1.3)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
+  async-websocket (~> 0.8.0)
   blanket_wrapper
-  celluloid-io
   dotenv
   nokogiri
-  pry
   rspotify
   slack-ruby-bot
 
-RUBY VERSION
-   ruby 2.3.1p112
-
 BUNDLED WITH
-   1.14.5
+   2.0.1


### PR DESCRIPTION
slack-ruby-client recommends using async-websocket: https://github.com/slack-ruby/slack-ruby-client#async

I also removed the explicit ruby version from the Gemfile and removed pry as it's not needed to run the bot.  This pulls the remaining dependencies up to latest.

Note that I needed to pin async-websocket to 0.8.0 as the API is in flux after that.  See: https://github.com/slack-ruby/slack-ruby-client/pull/268